### PR TITLE
Change source command because of error

### DIFF
--- a/harp-daal-app/README.md
+++ b/harp-daal-app/README.md
@@ -79,7 +79,7 @@ cd harp-daal-app/daal-src
 # compile and install
 make daal PLAT=lnx32e
 # setup the DAALROOT environment variables
-source ../__release_lnx/daal/bin/daalvars.sh 
+source ../__release_lnx/daal/bin/daalvars.sh intel64
 ```
 The DAAL source code within DSC-SPIDAL/harp has some modifications upon a certain version of Intel DAAL source code. 
 The current source code is based on Intel DAAL version 2018 beta update1. Installation from Intel DAAL latest version 


### PR DESCRIPTION
Error -
Syntax: source daalvars.sh <arch>
Where <arch> is one of:
  ia32      - setup environment for IA-32 architecture
  intel64   - setup environment for Intel(R) 64 architecture

If the arguments to the sourced script are ignored (consult docs for
your shell) the alternative way to specify target is environment
variables COMPILERVARS_ARCHITECTURE or DAALVARS_ARCHITECTURE to pass
<arch> to the script.