### PR TITLE
Change source command because of error

### DIFF
--- a/harp-daal-app/README.md
+++ b/harp-daal-app/README.md
@@ -66,7 +66,7 @@ cd daal
 # compile and install
 make daal PLAT=lnx32e
 # setup the DAALROOT environment variables
-source __release_lnx/daal/bin/daalvars.sh 
+source __release_lnx/daal/bin/daalvars.sh intel64
 ```
 2. Installation from optimized DAAL source code within DSC-SPIDAL/harp (Recommended)
 ```bash


### PR DESCRIPTION
Error -
Syntax: source daalvars.sh 
Where is one of:
ia32 - setup environment for IA-32 architecture
intel64 - setup environment for Intel(R) 64 architecture

If the arguments to the sourced script are ignored (consult docs for
your shell) the alternative way to specify target is environment
variables COMPILERVARS_ARCHITECTURE or DAALVARS_ARCHITECTURE to pass
to the script.